### PR TITLE
Fix npm start after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build --config ./vite.config.ts && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "node -r ./load-env.js dist/index.js",
+    "start": "node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },


### PR DESCRIPTION
## Summary
- remove leftover `load-env.js` reference in `npm start` script

## Testing
- `npm run check`
- `npm run build`
- `npm start` *(fails to connect to DB, but server starts and reads env)*

------
https://chatgpt.com/codex/tasks/task_e_688ce0896d9c833092ad3942db75daf6