### PR TITLE
Serve static files from dist directory

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -72,7 +72,13 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(__dirname, "public");
+  // When running the server in production we expect the client
+  // build output to live in the top-level `dist/public` directory.
+  // In development the server is executed from the `server` directory
+  // while the compiled production build runs from `dist`. Resolving the
+  // path using the project root ensures static files are found in both
+  // scenarios.
+  const distPath = path.resolve(__dirname, "..", "dist", "public");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
## Summary
- ensure Express serves client build from the top-level `dist/public` directory so static assets are available when the server runs from different locations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688da7b937a08330927b8a4334b78a80