### PR TITLE
Ensure production env in start script and clarify deployment build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,13 @@ npm install --save-dev vite @vitejs/plugin-react esbuild typescript @replit/vite
 ```
 
 #### 7. Build the application
+Run the production build so the `dist/public` directory is generated:
 ```bash
 npm run build
 ```
 
 #### 8. Start the server
-# Run the application
+Run the application **after** building:
 ```bash
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build --config ./vite.config.ts && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "node dist/index.js",
+    "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },


### PR DESCRIPTION
## Summary
- Set `npm start` script to run with `NODE_ENV=production`
- Emphasize running `npm run build` before starting server to generate `dist/public`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688db49288308330904672c3b146c500