### PR TITLE
chore: ensure newline at end of vite config

### DIFF
--- a/vite.config.alternative.ts
+++ b/vite.config.alternative.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import themePlugin from "@replit/vite-plugin-shadcn-theme-json";
 import path from "path";
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from "url";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 // Use this approach instead of import.meta.dirname


### PR DESCRIPTION
## Summary
- add trailing newline to `vite.config.alternative.ts`
- format vite config with Prettier for consistent quotes

## Testing
- `npx -y prettier vite.config.alternative.ts --check`
- `npm run check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688db9ef56608330a2be4a95e19bece9