### PR TITLE
Validate stored hash format in comparePasswords

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -35,8 +35,19 @@ async function hashPassword(password: string): Promise<string> {
  */
 async function comparePasswords(supplied: string, stored: string): Promise<boolean> {
   const [hashed, salt] = stored.split(".");
+  if (!hashed || !salt) {
+    console.warn("Invalid stored hash format");
+    return false;
+  }
+
   const hashedBuf = Buffer.from(hashed, "hex");
   const suppliedBuf = (await scryptAsync(supplied, salt, 64)) as Buffer;
+
+  if (hashedBuf.length !== suppliedBuf.length) {
+    console.warn("Hash length mismatch");
+    return false;
+  }
+
   return timingSafeEqual(hashedBuf, suppliedBuf);
 }
 


### PR DESCRIPTION
## Summary
- Check for missing hashed or salt parts in stored password string and fail early with a warning
- Compare hashed and supplied password lengths before using timingSafeEqual to avoid errors, logging mismatches

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688e2831108c8330bd22f49bdea88cbb