### PR TITLE
Validate stored password hash format

### DIFF
--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+const { comparePasswords } = await import('./auth.ts');
+
+test('comparePasswords returns false for malformed stored strings', async () => {
+  const result = await comparePasswords('password', 'invalid');
+  assert.equal(result, false);
+});
+
+test('comparePasswords returns false when stored has too many parts', async () => {
+  const result = await comparePasswords('password', 'a.b.c');
+  assert.equal(result, false);
+});

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -33,11 +33,23 @@ async function hashPassword(password: string): Promise<string> {
 /**
  * Securely compare stored password hash with supplied password
  */
-async function comparePasswords(supplied: string, stored: string): Promise<boolean> {
-  const [hashed, salt] = stored.split(".");
-  const hashedBuf = Buffer.from(hashed, "hex");
-  const suppliedBuf = (await scryptAsync(supplied, salt, 64)) as Buffer;
-  return timingSafeEqual(hashedBuf, suppliedBuf);
+export async function comparePasswords(
+  supplied: string,
+  stored: string,
+): Promise<boolean> {
+  const parts = stored.split(".");
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const [hashed, salt] = parts;
+  try {
+    const hashedBuf = Buffer.from(hashed, "hex");
+    const suppliedBuf = (await scryptAsync(supplied, salt, 64)) as Buffer;
+    return timingSafeEqual(hashedBuf, suppliedBuf);
+  } catch {
+    return false;
+  }
 }
 
 // Create a strong session secret


### PR DESCRIPTION
## Summary
- ensure comparePasswords handles malformed stored hashes
- add tests for malformed password strings

## Testing
- `npm run check`
- `npx tsx --test server/auth.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688e29686f148330917e40830e8fe510