### PR TITLE
Send WhatsApp messages on campaign creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,9 @@ SES_SENDER=sender@example.com
 # Campaign API Configuration
 CAMPAIGN_API_URL=https://your-api-endpoint.example.com/campaign
 
+# WhatsApp Business API configuration
+# Base URL including API version and phone number id, e.g.
+# https://graph.facebook.com/v19.0/123456789/messages
+WABA_API_URL=https://graph.facebook.com/v19.0/FROM_PHONE_NUMBER_ID/messages
+WABA_ACCESS_TOKEN=YOUR_WHATSAPP_ACCESS_TOKEN
+

--- a/scripts/create_tables.sql
+++ b/scripts/create_tables.sql
@@ -68,6 +68,19 @@ CREATE TABLE IF NOT EXISTS analytics (
 CREATE INDEX IF NOT EXISTS idx_analytics_campaign_id ON analytics(campaign_id);
 CREATE INDEX IF NOT EXISTS idx_analytics_account_id ON analytics(account_id);
 
+-- Create messages table
+CREATE TABLE IF NOT EXISTS messages (
+  id SERIAL PRIMARY KEY,
+  campaign_id INTEGER NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  contact_id INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  message_id TEXT,
+  status TEXT NOT NULL DEFAULT 'sent',
+  error TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_messages_campaign_id ON messages(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_messages_contact_id ON messages(contact_id);
+
 -- Create settings table
 CREATE TABLE IF NOT EXISTS settings (
   id SERIAL PRIMARY KEY,

--- a/server/config.ts
+++ b/server/config.ts
@@ -87,6 +87,11 @@ export const API_CONFIG = {
   campaign: {
     apiKey: process.env.CAMPAIGN_API_KEY,
     apiUrl: process.env.CAMPAIGN_API_URL || "https://8x83b7rn4f.execute-api.ap-south-1.amazonaws.com/qa/campaign"
+  },
+  // WhatsApp Business API settings
+  waba: {
+    apiUrl: process.env.WABA_API_URL || "",
+    accessToken: process.env.WABA_ACCESS_TOKEN || ""
   }
 };
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -98,6 +98,25 @@ export const insertAnalyticsSchema = createInsertSchema(analytics).pick({
   accountId: true,
 });
 
+// Messages schema
+export const messages = pgTable("messages", {
+  id: serial("id").primaryKey(),
+  campaignId: integer("campaign_id").notNull().references(() => campaigns.id),
+  contactId: integer("contact_id").notNull().references(() => contacts.id),
+  messageId: text("message_id"),
+  status: text("status").notNull().default("sent"),
+  error: text("error"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const insertMessageSchema = createInsertSchema(messages).pick({
+  campaignId: true,
+  contactId: true,
+  messageId: true,
+  status: true,
+  error: true,
+});
+
 // Define types
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
@@ -113,6 +132,9 @@ export type Campaign = typeof campaigns.$inferSelect;
 
 export type InsertAnalytics = z.infer<typeof insertAnalyticsSchema>;
 export type Analytics = typeof analytics.$inferSelect;
+
+export type InsertMessage = z.infer<typeof insertMessageSchema>;
+export type Message = typeof messages.$inferSelect;
 
 // Settings schema
 export const settings = pgTable("settings", {


### PR DESCRIPTION
## Summary
- send WABA template messages to all campaign contacts when a campaign is created
- log each message and update analytics
- configure WhatsApp Business API URL and token via environment variables
- add persistent messages table for reporting

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688eca7d4b388330beccb2fe9242bb92