### PR TITLE
chore: add ssh troubleshooting step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Debug SSH connection
+        run: |
+          echo "${{ secrets.EC2_SSH_KEY }}" > debug_key.pem
+          chmod 600 debug_key.pem
+          ssh -vvv -o StrictHostKeyChecking=no -i debug_key.pem ${{ vars.EC2_USER }}@${{ vars.EC2_HOST }} "echo 'SSH connection successful'"
+          rm debug_key.pem
+
       - name: Deploy to server
         uses: appleboy/scp-action@master
         with:
@@ -31,6 +38,7 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           source: "dist/*"
           target: "/var/www/reach.cogzi.io/releases/$(date +'%Y%m%d%H%M%S')"
+          debug: true
 
       - name: Finalize deployment
         uses: appleboy/ssh-action@master
@@ -38,6 +46,7 @@ jobs:
           host: ${{ vars.EC2_HOST }}
           username: ${{ vars.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          debug: true
           script: |
             RELEASE_DIR="/var/www/reach.cogzi.io/releases"
             CURRENT_LINK="/var/www/reach.cogzi.io/current"
@@ -57,6 +66,7 @@ jobs:
           host: ${{  vars.EC2_HOST }}
           username: ${{ vars.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          debug: true
           script: |
             RELEASE_DIR="/var/www/reach.cogzi.io/releases"
             CURRENT_LINK="/var/www/reach.cogzi.io/current"


### PR DESCRIPTION
## Summary
- add debugging step to verify SSH connectivity prior to deployment
- enable debug output for deployment and rollback SSH actions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6897095f6e7c83309031b0b2d3504162