### PR TITLE
Avoid runtime vite dependency in server build

### DIFF
--- a/server/email.ts
+++ b/server/email.ts
@@ -1,5 +1,5 @@
 import AWS from 'aws-sdk';
-import { log } from './vite';
+import { log } from './logger';
 import { EMAIL_CONFIG } from './config';
 
 // Get credentials from configuration

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,8 @@ import "./config";
 
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
+import { serveStatic } from "./vite";
+import { log } from "./logger";
 import cors from "cors";
 import { SERVER_CONFIG } from "./config";
 
@@ -77,6 +78,7 @@ app.use((req, res, next) => {
   // setting up all the other routes so the catch-all route
   // doesn't interfere with the other routes
   if (app.get("env") === "development") {
+    const { setupVite } = await import("./vite");
     await setupVite(app, server);
   } else {
     serveStatic(app);

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,0 +1,10 @@
+export function log(message: string, source = "express") {
+  const formattedTime = new Date().toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+
+  console.log(`${formattedTime} [${source}] ${message}`);
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -2,28 +2,19 @@ import { fileURLToPath } from "url";
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
-
-const viteLogger = createLogger();
+import type { ServerOptions } from "vite";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export function log(message: string, source = "express") {
-  const formattedTime = new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
-
-  console.log(`${formattedTime} [${source}] ${message}`);
-}
-
 export async function setupVite(app: Express, server: Server) {
+  const { createServer: createViteServer, createLogger } = await import("vite");
+  const viteConfigPath = path.resolve(__dirname, "..", "vite.config.ts");
+  const viteConfig = (await import(viteConfigPath))?.default ?? {};
+  const viteLogger = createLogger();
+
   const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },


### PR DESCRIPTION
## Summary
- separate logger from vite utilities so production server doesn't pull in Vite
- dynamically import Vite and config only in development to avoid runtime dependency
- update email and server entry points to use new logger

## Testing
- `npm run build`
- `npm run check`
- `rg "from \"vite\"" dist/index.js`


------
https://chatgpt.com/codex/tasks/task_e_689753b71ad083308f6a3659c48816ae