### PR TITLE
Avoid runtime Vite dependency in server

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,7 @@ import "./config";
 
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
-import { serveStatic } from "./vite";
+import { serveStatic } from "./static";
 import { log } from "./logger";
 import cors from "cors";
 import { SERVER_CONFIG } from "./config";

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from "url";
+import express, { type Express } from "express";
+import fs from "fs";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export function serveStatic(app: Express) {
+  // When running the server in production we expect the client
+  // build output to live directly in the top-level `dist` directory.
+  // In development the server is executed from the `server` directory
+  // while the compiled production build runs from `dist`. Resolving the
+  // path using the project root ensures static files are found in both
+  // scenarios.
+  const distPath = path.resolve(__dirname, "..", "dist");
+
+  if (!fs.existsSync(distPath)) {
+    throw new Error(
+      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+    );
+  }
+
+  app.use(express.static(distPath));
+
+  // fall through to index.html if the file doesn't exist
+  app.use("*", (_req, res) => {
+    res.sendFile(path.resolve(distPath, "index.html"));
+  });
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -61,26 +61,3 @@ export async function setupVite(app: Express, server: Server) {
     }
   });
 }
-
-export function serveStatic(app: Express) {
-  // When running the server in production we expect the client
-  // build output to live directly in the top-level `dist` directory.
-  // In development the server is executed from the `server` directory
-  // while the compiled production build runs from `dist`. Resolving the
-  // path using the project root ensures static files are found in both
-  // scenarios.
-  const distPath = path.resolve(__dirname, "..", "dist");
-
-  if (!fs.existsSync(distPath)) {
-    throw new Error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`,
-    );
-  }
-
-  app.use(express.static(distPath));
-
-  // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
-  });
-}


### PR DESCRIPTION
## Summary
- Stop importing Vite utilities in production by extracting static file serving into its own module
- Load Vite dev server only when running in development

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897561dc8e88330a2ae279d1f3cd0b0